### PR TITLE
Add ruby 2.6

### DIFF
--- a/devdocs-lookup.el
+++ b/devdocs-lookup.el
@@ -343,6 +343,7 @@
     ("Ruby 2.3" "ruby~2.3")
     ("Ruby 2.4" "ruby~2.4")
     ("Ruby 2.5" "ruby~2.5")
+    ("Ruby 2.6" "ruby~2.6")
     ("Ruby on Rails 4.1" "rails~4.1")
     ("Ruby on Rails 4.2" "rails~4.2")
     ("Ruby on Rails 5.0" "rails~5.0")


### PR DESCRIPTION
# Summary

devdocs has supported ruby 2.6

<img width="782" alt="Screenshot 2019-10-13 22 25 04" src="https://user-images.githubusercontent.com/1622392/66717933-51246700-ee08-11e9-9e4f-5d64ad6cb8da.png">
