### PR TITLE
Update devdocs base index URL

### DIFF
--- a/devdocs-lookup.el
+++ b/devdocs-lookup.el
@@ -44,7 +44,7 @@
 (defvar devdocs-base-url "https://devdocs.io"
   "Base url for devdocs.io.")
 
-(defvar devdocs-base-index-url "https://docs.devdocs.io"
+(defvar devdocs-base-index-url "https://documents.devdocs.io"
   "Base url for devdocs.io.")
 
 (defvar devdocs-subjects


### PR DESCRIPTION
Fixes "Name or service not known" error when trying to lookup.

```shell
# host docs.devdocs.io
Host docs.devdocs.io not found: 3(NXDOMAIN)
```