### PR TITLE
Quote major-mode-string when regexp-matching

### DIFF
--- a/devdocs-lookup.el
+++ b/devdocs-lookup.el
@@ -513,8 +513,9 @@ case-sensitive."
    (let* ((case-fold-search t)
           (major-mode-string
            (replace-regexp-in-string "-mode$" "" (symbol-name major-mode)))
-          (subject-dwim (cadr (cl-assoc major-mode-string devdocs-subjects
-                                        :test #'string-match-p)))
+          (subject-dwim
+	   (cadr (cl-assoc (regexp-quote major-mode-string) devdocs-subjects
+                           :test #'string-match-p)))
           (subject (if current-prefix-arg
                        (devdocs-read-subject)
                      (or devdocs--default-subject


### PR DESCRIPTION
This prevents the unwanted interpretation of regexp syntax in names
modes like "c++".

`devdocs-lookup` in `c++` mode suggested "Apa**c**he Documentation"